### PR TITLE
WIP: example stg-2 disk block list structures

### DIFF
--- a/fileblock/src/simplefs.rs
+++ b/fileblock/src/simplefs.rs
@@ -1,0 +1,25 @@
+// slightly arbitrary size of our "disk": 4GIB, broken into 4KiB blocks
+// 4 * 2.pow(30) / 4096 == 2Kib required to store bitmap
+const BITMAP_LEN: usize = 1048576_usize;
+
+/// disk block free list 
+/// persistent tracking of what blocks have been allocated.
+/// option 1: Bitmap! naive style
+struct  DiskBlockFreelist {
+    // keep an array of bits indicating whether a file
+    bits: [usize; BITMAP_LEN]
+}
+
+/// option 2: B-Tree!!
+/// wip...
+struct DiskBlockFreeTree {
+    count: u32,
+}
+
+struct Node {
+    val: u32,
+    // don't know how to imlement this yet without a Box; is it even possible?
+    // children: [DiskBlockFreeTree; BITMAP_LEN]
+}
+
+

--- a/fileblock/src/simplefs.rs
+++ b/fileblock/src/simplefs.rs
@@ -1,13 +1,13 @@
 // slightly arbitrary size of our "disk": 4GIB, broken into 4KiB blocks
 // 4 * 2.pow(30) / 4096 == 2Kib required to store bitmap
-const BITMAP_LEN: usize = 1048576_usize;
+const BITMAP_LIMIT: usize = 1048576_usize;
 
 /// disk block free list 
 /// persistent tracking of what blocks have been allocated.
 /// option 1: Bitmap! naive style
 struct  DiskBlockFreelist {
     // keep an array of bits indicating whether a file
-    bits: [usize; BITMAP_LEN]
+    bits: [usize; BITMAP_LIMIT]
 }
 
 /// option 2: B-Tree!!
@@ -19,7 +19,7 @@ struct DiskBlockFreeTree {
 struct Node {
     val: u32,
     // don't know how to imlement this yet without a Box; is it even possible?
-    // children: [DiskBlockFreeTree; BITMAP_LEN]
+    // children: [DiskBlockFreeTree; BITMAP_LIMIT]
 }
 
 


### PR DESCRIPTION
# discussion
here's a quickish brain dump getting started at stage 2 data structures for file system. 
I'm hoping to throw this out and work on it asynchronously bc I have to steal my minutes in the week when i can. 

specifically from [here in the lab](https://web.mit.edu/6.033/1997/handouts/html/04sfs.html)
>  There are three main data structures file systems manage...:
> 1. A disk block freelist. This is a simple data structure (for instance, a bitmap) that tracks what blocks on the disk have been allocated. This data structure is, for obvious reasons, persistent (i.e., on disk). You will have to establish some convention for locating it across reboots. 

## option 1:
bitmap
this seems like easiest and most intuitive to blunder through. Tradeoffs seem to be space and time. I'm okay with big and slow at thsi point

--- but ---
## option 2
B - Tree!
this seems doable and better for at least time, likely not space tho? 

few questions on it
1. how to implement recurisve `structs` i'm going back to [this post for a refresher](https://rust-unofficial.github.io/too-many-lists/first-layout.html)
2. how to persist this to disk -- not sure yet what would be the simple dumb way to persist this to a file. how do you model a btree in a flat file  on disk!? no good ideas off top of my head
3. more later-down concerns with allocation. 
